### PR TITLE
feat: Auto close modal on vote

### DIFF
--- a/decidim-budgets_booth/app/views/decidim/budgets/line_items/update_budget.js.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/line_items/update_budget.js.erb
@@ -17,6 +17,7 @@ if ($projectItem.length > 0) {
 }
 
 if ($projectModal.length > 0) {
+  $projectModal.foundation("close"); // Close the modal when button has been clicked
   var $projectModalButtonForm = $(".project-vote-button", $projectModal).parent();
   morphdom($projectModalButtonForm[0], '<%= j(cell("decidim/budgets/project_vote_button", project, scale_up: true)).strip.html_safe %>');
 }


### PR DESCRIPTION
#### Description

In budget booth, when user clicks on "Read more" link and click on "Add to your vote", modal is automatically hidden


<img width="600" alt="Screenshot 2024-05-30 at 11 33 26" src="https://github.com/OpenSourcePolitics/decidim-module-ptp/assets/26109239/97f1aa81-c87e-45b0-9d2e-8f8b43530e2b">

