### PR TITLE
fix: Check current_order when reviewing user vote

### DIFF
--- a/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
+++ b/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
@@ -52,10 +52,9 @@ module Decidim
         end
 
         def order
-          result = Decidim::Budgets::Order.find_by(decidim_budgets_budget_id: params[:budget_id])
-          return nil unless result && result.checked_out_at.present?
+          return unless current_order.present? && current_order.checked_out_at.present?
 
-          result
+          current_order
         end
       end
     end


### PR DESCRIPTION
#### Description 

It fixes "Review your vote" button. 

![Screenshot 2024-06-10 at 13 51 34](https://github.com/OpenSourcePolitics/decidim-module-ptp/assets/26109239/d647c5c9-1aa9-4620-a609-1d42d6584615)
