### PR TITLE
fix:send notifications after voting

### DIFF
--- a/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
+++ b/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
@@ -69,7 +69,6 @@ module Decidim
               budget_name: order.budget.title
             }
           )
-          Rails.logger.debug 'Notification sent for order #{order.id}'
         end
       end
     end

--- a/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
+++ b/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/orders_controller_extensions.rb
@@ -65,7 +65,6 @@ module Decidim
             resource: order,
             affected_users: [order.user],
             extra: {
-              order_id: order.id,
               budget_name: order.budget.title
             }
           )

--- a/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
+++ b/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
@@ -5,6 +5,10 @@ module Decidim
     class OrderCreatedEvent < Decidim::Events::BaseEvent
       include Decidim::Events::NotificationEvent
 
+      def self.model_name
+        ActiveModel::Name.new(self, nil, I18n.t('decidim.budgets.voting.order_created_event.notification_casted'))
+      end
+
       def notification_title
         I18n.t(
           'decidim.budgets.voting.voting_notification_event.notification_title',

--- a/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
+++ b/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Decidim
+  module BudgetsBooth
+    class OrderCreatedEvent < Decidim::Events::BaseEvent
+      include Decidim::Events::NotificationEvent
+
+      def notification_title
+        I18n.t(
+          'decidim.budgets_booth.order_created_event.notification_title',
+        order_id: resource.id
+        )
+      end
+
+      def notification_body
+        I18n.t('decidim.budgets_booth.order_created_event.notification_body',
+               user_name: resource.user.name,
+               budget_name: resource.budget.title
+        )
+      end
+
+      private
+
+      def resource_title
+        resource.budget.title
+      end
+
+      def resource_path
+        Decidim::Engine.routes.url_helpers.budget_path(resource.budget)
+      end
+    end
+  end
+end

--- a/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
+++ b/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
@@ -7,13 +7,12 @@ module Decidim
 
       def notification_title
         I18n.t(
-          'decidim.budgets_booth.order_created_event.notification_title',
-        order_id: resource.id
+          'decidim.budgets.voting.voting_notification_event.notification_title',
         )
       end
 
       def notification_body
-        I18n.t('decidim.budgets_booth.order_created_event.notification_body',
+        I18n.t('decidim.budgets.voting.voting_notification_event.notification_body',
                user_name: resource.user.name,
                budget_name: resource.budget.title
         )

--- a/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
+++ b/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
@@ -8,20 +8,14 @@ module Decidim
       def notification_title
         I18n.t(
           'decidim.budgets.voting.voting_notification_event.notification_title',
-        )
-      end
-
-      def notification_body
-        I18n.t('decidim.budgets.voting.voting_notification_event.notification_body',
-               user_name: resource.user.name,
-               budget_name: resource.budget.title
-        )
+          budget_name: resource_title
+          )
       end
 
       private
 
       def resource_title
-        resource.budget.title
+        translated_attribute(resource.budget.title)
       end
 
       def resource_path

--- a/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
+++ b/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
@@ -6,7 +6,7 @@ module Decidim
       include Decidim::Events::NotificationEvent
 
       def self.model_name
-        ActiveModel::Name.new(self, nil, I18n.t('decidim.budgets.voting.order_created_event.notification_casted'))
+        ActiveModel::Name.new(self, nil, I18n.t('decidim.budgets.voting.voting_notification_event.notification_casted'))
       end
 
       def notification_title

--- a/decidim-budgets_booth/config/locales/en.yml
+++ b/decidim-budgets_booth/config/locales/en.yml
@@ -145,6 +145,9 @@ en:
           label: Close
           list_description: These are the projects you picked.
           title: Your vote
+        voting_notification_event:
+          notification_title: You have successfully cast your vote for the budget %{budget_name}.
+          notification_body: You have successfully cast your vote for the budget %{budget_name}.
     components:
       budgets:
         settings:

--- a/decidim-budgets_booth/config/locales/en.yml
+++ b/decidim-budgets_booth/config/locales/en.yml
@@ -146,8 +146,7 @@ en:
           list_description: These are the projects you picked.
           title: Your vote
         voting_notification_event:
-          notification_title: You have successfully cast your vote for the budget %{budget_name}.
-          notification_body: You have successfully cast your vote for the budget %{budget_name}.
+          notification_title: You have successfully cast your vote for the budget %{budget_name}
     components:
       budgets:
         settings:

--- a/decidim-budgets_booth/config/locales/en.yml
+++ b/decidim-budgets_booth/config/locales/en.yml
@@ -146,6 +146,7 @@ en:
           list_description: These are the projects you picked.
           title: Your vote
         voting_notification_event:
+          notification_casted: Your vote has been casted
           notification_title: You have successfully cast your vote for the budget %{budget_name}
     components:
       budgets:

--- a/decidim-budgets_booth/config/locales/fi.yml
+++ b/decidim-budgets_booth/config/locales/fi.yml
@@ -133,6 +133,9 @@ fi:
           label: Sulje
           list_description: Valitsit nämä hankkeet.
           title: Äänesi
+        voting_notification_event:
+          notification_casted: Äänestys on suoritettu
+          notification_title: Olet onnistuneesti äänestänyt budjetista %{budget_name}
     components:
       budgets:
         settings:

--- a/decidim-budgets_booth/config/locales/fr.yml
+++ b/decidim-budgets_booth/config/locales/fr.yml
@@ -134,8 +134,8 @@ fr:
           list_description: Voici les projets que vous avez sélectionnés.
           title: Votre vote
         voting_notification_event:
-          notification_title: Votre vote a été enregistré
-          notification_body: Vous avez voté avec succès pour le budget %{budget_name}.
+          notification_casted: Votre vote a été enregistré
+          notification_title: Vous avez voté avec succès pour le budget %{budget_name}
     components:
       budgets:
         settings:

--- a/decidim-budgets_booth/config/locales/fr.yml
+++ b/decidim-budgets_booth/config/locales/fr.yml
@@ -133,6 +133,9 @@ fr:
           label: Fermer
           list_description: Voici les projets que vous avez sélectionnés.
           title: Votre vote
+        voting_notification_event:
+          notification_title: Votre vote a été enregistré
+          notification_body: Vous avez voté avec succès pour le budget %{budget_name}.
     components:
       budgets:
         settings:

--- a/decidim-budgets_booth/spec/controllers/concerns/decidim/budgets_booth/orders_controller_extensions_spec.rb
+++ b/decidim-budgets_booth/spec/controllers/concerns/decidim/budgets_booth/orders_controller_extensions_spec.rb
@@ -38,6 +38,12 @@ describe Decidim::BudgetsBooth::OrdersControllerExtensions, type: :controller do
         expect(response).to redirect_to(decidim_budgets.budgets_path)
         expect(session[:booth_thanks_message]).to be(true)
       end
+
+      it "enqueues job" do
+        expect do
+          post :checkout, params: { budget_id: budgets.first.id, component_id: component.id, participatory_process_slug: component.participatory_space.slug }
+        end.to have_enqueued_job(Decidim::EventPublisherJob)
+      end
     end
 
     context "when invalid" do


### PR DESCRIPTION
🎩 Description
Budget Booth, the vote confirmation is neither notified or sent by email.

📌 Related Issues
[Notion card](https://www.notion.so/opensourcepolitics/Lyon-Dev-Budget-Booth-la-confirmation-du-vote-n-est-pas-notifi-e-ni-envoy-e-par-mail-9f649dc61dd14ac0b58ae3693231f4ca?pvs=4)

Testing

**Dashboard**

1. As an admin, go to a process.
2. Go to the budget setting (in components, click on the settings icon).
3. Click on **“Vote in one: allows participants to vote in any budget, but only in one.”** and **“Voting enabled.”**
4. 
<img width="596" alt="Capture d’écran 2024-07-29 à 13 10 53" src="https://github.com/user-attachments/assets/2a962e26-8e98-4107-8bd5-8fe9b2faa7c0">
<img width="1183" alt="Capture d’écran 2024-07-29 à 15 45 36" src="https://github.com/user-attachments/assets/aa9517e5-8ef9-4306-a59f-e9f7c5901f4d">

5. Update.

**Front-end**

1. Go to the process you changed.
2. Go to budgets.
3. Start voting (enter the budget booth).
4. Vote.
5. Go to your notifications and confirm that you received one about your vote.
6. Go to [http://localhost:3000/letter_opener](http://localhost:3000/letter_opener) and confirm that you received an email about your vote.
7.
<img width="1487" alt="Capture d’écran 2024-07-31 à 12 05 41" src="https://github.com/user-attachments/assets/13810348-4e8d-4869-9125-a4e5a678029c">
