### PR TITLE
feat: add map on project index view

### DIFF
--- a/.github/actions/module-rspec/action.yml
+++ b/.github/actions/module-rspec/action.yml
@@ -14,6 +14,11 @@ runs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+    - run: |
+        sudo apt update
+        sudo apt install libu2f-udev imagemagick
+      name: Install libu2f-udev & imagemagick
+      shell: "bash"
     - uses: actions/setup-node@v3
       with:
         node-version: 16
@@ -44,7 +49,7 @@ runs:
       working-directory: ${{ inputs.name }}
       shell: "bash"
     - uses: codecov/codecov-action@v3
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: screenshots

--- a/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
+++ b/decidim-budgets_booth/app/events/decidim/budgets_booth/order_created_event.rb
@@ -6,14 +6,14 @@ module Decidim
       include Decidim::Events::NotificationEvent
 
       def self.model_name
-        ActiveModel::Name.new(self, nil, I18n.t('decidim.budgets.voting.voting_notification_event.notification_casted'))
+        ActiveModel::Name.new(self, nil, I18n.t("decidim.budgets.voting.voting_notification_event.notification_casted"))
       end
 
       def notification_title
         I18n.t(
-          'decidim.budgets.voting.voting_notification_event.notification_title',
+          "decidim.budgets.voting.voting_notification_event.notification_title",
           budget_name: resource_title
-          )
+        )
       end
 
       private

--- a/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
@@ -4,6 +4,31 @@
 
 <div class="voting-wrapper <%="margin-top-3" if voting_booth_forced? %>">
   <div class="row columns">
+    <% if component_settings.geocoding_enabled? %>
+      <%= dynamic_map_for projects_data_for_map(all_geocoded_projects) do %>
+        <template id="marker-popup">
+          <div class="map-info__content">
+            <h3>${title}</h3>
+            <div id="bodyContent">
+              <p>{{html body}}</p>
+              <div class="map__date-address">
+                <div class="address card__extra">
+                  <div class="address__icon">{{html icon}}</div>
+                  <div class="address__details">
+                    <span>${address}</span><br>
+                  </div>
+                </div>
+              </div>
+              <div class="map-info__button">
+                <a href="${link}" class="button button--sc">
+                  <%= t(".view_project") %>
+                </a>
+              </div>
+            </div>
+          </div>
+        </template>
+      <% end %>
+    <% end %>
     <% if voting_finished? %>
       <h2 class="heading2">
         <%= t("decidim.budgets.projects.projects_for", name: translated_attribute(budget.title)) %>

--- a/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
+++ b/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
@@ -111,8 +111,8 @@ describe "Non zip code workflow", type: :system do
           end
           within ".reveal-overlay" do
             click_button "Remove from vote"
-            expect(page).to have_button("Add to your vote", count: 1)
           end
+          expect(page).to have_button("Add to your vote", count: 1)
         end
 
         context "when full-text is enabled" do

--- a/decidim-budgets_booth/spec/system/voting_index_page_spec.rb
+++ b/decidim-budgets_booth/spec/system/voting_index_page_spec.rb
@@ -159,8 +159,8 @@ describe "Voting index page", type: :system do
       end
       within ".reveal-overlay" do
         click_button "Remove from vote"
-        expect(page).to have_button("Add to your vote", count: 1)
       end
+      expect(page).to have_button("Add to your vote", count: 5)
     end
 
     describe "filtering projects" do


### PR DESCRIPTION
🎩 Description
The aim of this PR is to display the map in project index view when geocoding is enabled on budgets.

📌 Related Issues
Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=104536367&issue=OpenSourcePolitics%7Cdecidim-lyon%7C137

Testing

1. To test the PR, go to decidim-lyon develop and update in the gemfile the line for budgets_booth gem like this `gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "feat/add_map_in_projects_index"`
2. Bundle install 
3. As an admin, create a Budgets component and enable geocoding in the configuration page;
4. Go to the project settings and add addresses to projects (in the address field);
5. In FO, go to the projects index view: see that the map is displayed with the the projects adresses (cf screenshot)
6. Enter the voting booth and see that the map is still displayed

Screenshot
<img width="1234" alt="Capture d’écran 2025-04-03 à 11 24 57" src="https://github.com/user-attachments/assets/b48032e9-38e2-4b7f-83e7-553cfc8729fd" />
