### PR TITLE
fix: change explanation modal display

### DIFF
--- a/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/line_items_controller_extensions.rb
+++ b/decidim-budgets_booth/app/controllers/concerns/decidim/budgets_booth/line_items_controller_extensions.rb
@@ -21,16 +21,30 @@ module Decidim
           @show_help_modal =
             if current_workflow.try(:disable_voting_instructions?)
               false
-            elsif rule_enabled && line_items && minimum_vote == line_items.size + 1
-              # when we click to add a project, it has not yet been added in line items so we add + 1 to get the modal at the right time
-              true
+            elsif rule_enabled
+              show_modal(order, minimum_vote, line_items)
             else
               order.blank?
+              # case of first click without rule_enabled => we want the modal
             end
         end
 
         def order
           @order ||= Decidim::Budgets::Order.find_by(user: current_user, budget: budget)
+        end
+
+        def show_modal(order, minimum_vote, line_items)
+          # when the user first click to add a project, the order is no yet created
+          if order.blank?
+            #  case of the first click
+            # if minimum_vote is 1 => we want the modal
+            # if minimum_vote is not 1 => we don't want the modal
+            minimum_vote == 1
+          elsif line_items && minimum_vote == line_items.size + 1
+            # when user clicks to add a project, it has not yet been added in line items so we add + 1 to get the modal at the right time
+            # case of second/third... click => we want the modal when minimum_vote == line_items.size + 1
+            true
+          end
         end
       end
     end

--- a/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
+++ b/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
@@ -175,18 +175,37 @@ describe "Non zip code workflow", type: :system do
               end
             end
 
-            context "when minimun budget to vote is set" do
+            context "when min && max number of projects to vote on rule is set && minimum projects to vote is 1" do
               before do
-                component[:settings]["global"]["vote_selected_projects_minimum"] = 2
                 component[:settings]["global"]["vote_rule_selected_projects_enabled"] = true
+                component[:settings]["global"]["vote_selected_projects_minimum"] = 1
               end
 
-              it "shows how to vote when number of projects added matches the minimun budget" do
+              it "shows how to vote when number of projects added matches 1" do
+                visit decidim_budgets.budget_voting_index_path(budget)
+                click_button("Add to your vote", match: :first)
+                expect(page).to have_css("div#voting-help")
+                within "div#voting-help" do
+                  expect(page).to have_content("I understand how to vote")
+                end
+              end
+            end
+
+            context "when min && max number of projects to vote on rule is set && minimum projects to vote is 2" do
+              before do
+                component[:settings]["global"]["vote_rule_selected_projects_enabled"] = true
+                component[:settings]["global"]["vote_selected_projects_minimum"] = 2
+              end
+
+              it "shows how to vote when number of projects added matches 2" do
                 visit decidim_budgets.budget_voting_index_path(budget)
                 click_button("Add to your vote", match: :first)
                 expect(page).not_to have_css("div#voting-help")
                 click_button("Add to your vote")
                 expect(page).to have_css("div#voting-help")
+                within "div#voting-help" do
+                  expect(page).to have_content("I understand how to vote")
+                end
               end
             end
           end


### PR DESCRIPTION
🎩 Description
The aim of this PR is to complete this PR https://github.com/OpenSourcePolitics/decidim-module-ptp/pull/16 . 
The case of the first click to add project when order and line_items have not yet been created has been added.

📌 Related Issues
Related to https://github.com/OpenSourcePolitics/decidim-lyon/issues/136

Testing

1. As an admin, create a Budgets feature with the following voting rules: minimum 3 projects, maximum 5 projects to vote for;
2. Activate votes for this step;
3. Ensure you have 3 projects minimum in that budget;
4. As a user, access the voting booth by clicking on the button for voting in the Budget component;
5. Select the number of minimum projects (that the admin configured) to vote for;
6. See that a modal with explanations of the voting process displayed;
7. Finish your vote.

Tasks
[X ] Add specs