### PR TITLE
fix: update project index view to only get projects of the page on map

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint:
     name: Lint code
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
@@ -5,7 +5,8 @@
 <div class="voting-wrapper <%="margin-top-3" if voting_booth_forced? %>">
   <div class="row columns">
     <% if component_settings.geocoding_enabled? %>
-      <%= dynamic_map_for projects_data_for_map(all_geocoded_projects) do %>
+      <% page_geocoded_projects = Decidim::Budgets::Project.where(id: projects.map(&:id)).geocoded %>
+      <%= dynamic_map_for projects_data_for_map(page_geocoded_projects) do %>
         <template id="marker-popup">
           <div class="map-info__content">
             <h3>${title}</h3>


### PR DESCRIPTION
🎩 Description

This PR updates in decidim-budgets_booth the projects index view to display on the map only the geocoded projects of the page.


📌 Related to
- Github card => https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=109081684&issue=OpenSourcePolitics%7Cdecidim-lyon%7C145

#### Testing

1. To test the PR, go to decidim-lyon develop and update in the gemfile the line for budgets_booth gem like this `gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "fix/projects_display_on_map"`
2. Bundle install
3. As an admin, go to a process, go to the Budgets component and enable geocoding in the configuration page, and set the project per page to 3
4. Choose a budget with 2 projects.
5. Create  4 new projects with addresses.
6. In FO, go to the projects index view: see that the map is displayed and that the projects displayed on the map match the projects listed on the page.
7. Go to page 2, and check again that the projects displayed on the map match the projects listed on the page.
