### PR TITLE
Fix projects display on map with filters

### DIFF
--- a/decidim-budgets_booth/app/views/decidim/budgets/projects/_map.html.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/projects/_map.html.erb
@@ -1,0 +1,24 @@
+<% page_geocoded_projects = Decidim::Budgets::Project.where(id: projects.map(&:id)).geocoded %>
+<%= dynamic_map_for projects_data_for_map(page_geocoded_projects) do %>
+  <template id="marker-popup">
+    <div class="map-info__content">
+      <h3>${title}</h3>
+      <div id="bodyContent">
+        <p>{{html body}}</p>
+        <div class="map__date-address">
+          <div class="address card__extra">
+            <div class="address__icon">{{html icon}}</div>
+            <div class="address__details">
+              <span>${address}</span><br>
+            </div>
+          </div>
+        </div>
+        <div class="map-info__button">
+          <a href="${link}" class="button button--sc">
+            <%= t(".view_project") %>
+          </a>
+        </div>
+      </div>
+    </div>
+  </template>
+<% end %>

--- a/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
@@ -5,30 +5,9 @@
 <div class="voting-wrapper <%="margin-top-3" if voting_booth_forced? %>">
   <div class="row columns">
     <% if component_settings.geocoding_enabled? %>
-      <% page_geocoded_projects = Decidim::Budgets::Project.where(id: projects.map(&:id)).geocoded %>
-      <%= dynamic_map_for projects_data_for_map(page_geocoded_projects) do %>
-        <template id="marker-popup">
-          <div class="map-info__content">
-            <h3>${title}</h3>
-            <div id="bodyContent">
-              <p>{{html body}}</p>
-              <div class="map__date-address">
-                <div class="address card__extra">
-                  <div class="address__icon">{{html icon}}</div>
-                  <div class="address__details">
-                    <span>${address}</span><br>
-                  </div>
-                </div>
-              </div>
-              <div class="map-info__button">
-                <a href="${link}" class="button button--sc">
-                  <%= t(".view_project") %>
-                </a>
-              </div>
-            </div>
-          </div>
-        </template>
-      <% end %>
+      <div id="map-container">
+        <%= render partial: "map" %>
+      </div>
     <% end %>
     <% if voting_finished? %>
       <h2 class="heading2">

--- a/decidim-budgets_booth/app/views/decidim/budgets/projects/index.js.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/projects/index.js.erb
@@ -1,7 +1,37 @@
 var $projects = $('#projects');
 var $projectsCount = $('#projects-count');
 var $orderFilterInput = $('.order_filter');
+<% if component_settings.geocoding_enabled? %>
+  var $map = $('#map-container');
+  $map.html(' ');
+  $map.html('<%= j(render partial: "map").strip.html_safe %>');
+  // from map.js
+  var $mapElements = $("[data-decidim-map]");
+  $mapElements.each((_i, el) => {
+    const $map = $(el);
+    let mapId = $map.attr("id");
+    if (!mapId) {
+      mapId = `map-${Math.random().toString(36).substr(2, 9)}`;
+      $map.attr("id", mapId);
+    }
 
+    const mapConfig = $map.data("decidim-map");
+    const ctrl = window.Decidim.createMapController(mapId, mapConfig);
+    const map = ctrl.load();
+    map.setMaxZoom(14);
+    // from default.js
+    const tilesConfig = mapConfig.tileLayer;
+    L.tileLayer(tilesConfig.url, tilesConfig.options).addTo(map);
+    $map.data("map", map);
+    $map.data("map-controller", ctrl);
+
+    $map.trigger("configure.decidim", [map, mapConfig]);
+
+    ctrl.start();
+
+    $map.trigger("ready.decidim", [map, mapConfig]);
+  });
+<% end %>
 $projects.html('<%= j(render partial: "projects").strip.html_safe %>');
 $projectsCount.html('<%= j(render partial: "count").strip.html_safe %>');
 $orderFilterInput.val('<%= order %>');

--- a/decidim-budgets_booth/config/locales/en.yml
+++ b/decidim-budgets_booth/config/locales/en.yml
@@ -68,6 +68,8 @@ en:
           title: Are you sure you don't want to cast your vote?
         index:
           back_to_budgets: Back to budgets
+        map:
+          view_project: View project
         order_progress:
           ready: I am ready
           total_budget: 'Total budget: '

--- a/decidim-budgets_booth/config/locales/fr.yml
+++ b/decidim-budgets_booth/config/locales/fr.yml
@@ -65,6 +65,8 @@ fr:
           title: Êtes-vous certain de vouloir annuler votre vote ?
         index:
           back_to_budgets: Retour aux budgets
+        map:
+          view_project: Voir le projet
         order_progress:
           ready: Je suis prêt
           total_budget: 'Budget total: '


### PR DESCRIPTION
🎩 Description

This PR fixes in decidim-budgets_booth the projects displayed on the map only when using filters.

📌 Related to

Github card => https://github.com/OpenSourcePolitics/decidim-lyon/issues/145

Testing

1. To test the PR, go to decidim-lyon develop and update in the gemfile the line for budgets_booth gem like this `gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "fix/projects_display_on_map_with_filters"`
2. Bundle install
3. As an admin, go to a process, go to the Budgets component and enable geocoding in the configuration page, and set the project per page to 3
4. Choose a budget with 2 projects.
5. Create 4 new projects with addresses.
6. In FO, go to the projects index view: see that the map is displayed and that the projects displayed on the map match the projects listed on the page.
7. Use the filters and see that the projects displayed on the map are matching the projects listed on the page