### PR TITLE
feat: Remove voting instructions

### DIFF
--- a/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
+++ b/decidim-budgets_booth/app/views/decidim/budgets/projects/index.html.erb
@@ -32,6 +32,5 @@
     </div>
   </div>
 </div>
-<%= render partial: "decidim/budgets/partials/voting_help_modal" unless current_workflow.try(:disable_voting_instructions?) %>
 
 <%= javascript_pack_tag("decidim_budgets_booth_voting") %>

--- a/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
+++ b/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
@@ -98,8 +98,6 @@ describe "Non zip code workflow", type: :system do
         it "adds and removes projects" do
           expect(page).to have_button("Add to your vote", count: 2)
           click_button("Add to your vote", match: :first)
-          expect(page).to have_content("Your vote has not been cast.")
-          click_button "I understand how to vote"
           expect(page).to have_button("Add to your vote", count: 1)
           expect(page).to have_button("Remove from vote", count: 1)
 
@@ -164,12 +162,6 @@ describe "Non zip code workflow", type: :system do
           it "shows how to vote message by default" do
             visit decidim_budgets.budget_voting_index_path(budget)
             click_button("Add to your vote", match: :first)
-            expect(page).to have_css("div#voting-help")
-            within "div#voting-help" do
-              expect(page).to have_content("Your vote has not been cast.")
-              expect(page).to have_css("svg", count: 3)
-              expect(page).to have_content("I understand how to vote")
-            end
           end
 
           describe "thanks popup" do
@@ -296,7 +288,6 @@ describe "Non zip code workflow", type: :system do
   def vote_for_this(budget)
     visit decidim_budgets.budget_voting_index_path(budget)
     click_button("Add to your vote", match: :first)
-    click_button("I understand how to vote")
     click_button("Add to your vote", match: :first)
     click_button("I am ready")
     click_button("Confirm")

--- a/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
+++ b/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
@@ -159,27 +159,6 @@ describe "Non zip code workflow", type: :system do
             sign_in user
           end
 
-          describe "vote message popup" do
-            context "when default" do
-              it "shows how to vote message by default" do
-                visit decidim_budgets.budget_voting_index_path(budget)
-                click_button("Add to your vote", match: :first)
-              end
-            end
-
-            context "when min && max number of projects to vote on rule is set && minimum projects to vote is 1" do
-              before do
-                component[:settings]["global"]["vote_rule_selected_projects_enabled"] = true
-                component[:settings]["global"]["vote_selected_projects_minimum"] = 1
-              end
-
-              it "shows how to vote when number of projects added matches 1" do
-                visit decidim_budgets.budget_voting_index_path(budget)
-                click_button("Add to your vote", match: :first)
-              end
-            end
-          end
-
           describe "thanks popup" do
             context "when default" do
               before do

--- a/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
+++ b/decidim-budgets_booth/spec/system/non_zip_code_workflow_spec.rb
@@ -110,7 +110,7 @@ describe "Non zip code workflow", type: :system do
           within ".reveal-overlay" do
             click_button "Remove from vote"
           end
-          expect(page).to have_button("Add to your vote", count: 3)
+          expect(page).to have_button("Add to your vote", count: 2)
         end
 
         context "when full-text is enabled" do

--- a/decidim-budgets_booth/spec/system/voting_index_page_spec.rb
+++ b/decidim-budgets_booth/spec/system/voting_index_page_spec.rb
@@ -477,7 +477,6 @@ describe "Voting index page", type: :system do
 
   def non_zipcode_vote_budget!
     click_button("Add to your vote", match: :first)
-    click_button "I understand how to vote"
     click_button "I am ready"
     click_button "Confirm"
   end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

Remove voting instructions as it seemed not to be useful

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to [#19](https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=111473404&issue=OpenSourcePolitics%7Cintern-tasks%7C19)

#### Testing
- Setup your development app by running `bundle exec rake development_app && cd development_app && bundle exec rake assets:precompile`
- Access a participatory process
- Access budgets component
- Try to vote on a project
- Make sure on your first vote that the modal doesn't appear
- You can change account to make sure it works correctly
